### PR TITLE
vsphere_virtual_machine の firmware 追加

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ variable "prov_vm_num" {}            #プロビジョニングする仮想マシ
 variable "prov_vmname_prefix" {}     #プロビジョニングする仮想マシンの接頭語
 variable "prov_cpu_num" {}           #プロビジョニングする仮想マシンのCPUの数
 variable "prov_mem_num" {}           #プロビジョニングする仮想マシンのメモリのMB
+variable "prov_firmware" {}          #プロビジョニングする仮想マシンのファームウェア
 
 
 #Provider
@@ -61,6 +62,7 @@ resource "vsphere_virtual_machine" "vm" {
   guest_id = data.vsphere_virtual_machine.template.guest_id
 
   scsi_type = data.vsphere_virtual_machine.template.scsi_type
+  firmware = var.prov_firmware
 
   network_interface {
     network_id   = data.vsphere_network.network.id

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -13,3 +13,4 @@ prov_vm_num         = 1                             #プロビジョニングす
 prov_vmname_prefix  = "TFVM"                        #プロビジョニングする仮想マシンの接頭語
 prov_cpu_num        = 2                             #プロビジョニングする仮想マシンのCPUの数
 prov_mem_num        = 4096                          #プロビジョニングする仮想マシンのメモリのMB
+prov_firmware       = "bios"                        #プロビジョニングする仮想マシンのファームウェア


### PR DESCRIPTION
ファームウェアがEFIの仮想マシンをクローンする際に、BIOSに設定変更されてしまいゲストOSが起動できなくなっていた。

vsphere_virtual_machineリソースにfirmwareを明記して、bios or efiを指定しやすく変更してみた。
